### PR TITLE
Set glyph to inline-block

### DIFF
--- a/Leaflet.Icon.Glyph.js
+++ b/Leaflet.Icon.Glyph.js
@@ -60,10 +60,10 @@ L.Icon.Glyph = L.Icon.extend({
 		span.style.marginLeft = options.glyphAnchor[0] + 'px';
 		span.style.marginTop = options.glyphAnchor[1] + 'px';
 		span.style.pointerEvents = 'none';
+		span.style.display = 'inline-block';
 
 		if (textContent) {
 			span.innerHTML = textContent;
-			span.style.display = 'inline-block';
 		}
 
 		return span;


### PR DESCRIPTION
When using material design icons in vue-leaflet the glyph is not placed correctly. This fix the problem